### PR TITLE
Use animateTo on value update with the ValueNotifierAdapter

### DIFF
--- a/example/lib/examples/adapter_view.dart
+++ b/example/lib/examples/adapter_view.dart
@@ -26,7 +26,7 @@ class AdapterView extends StatelessWidget {
           ),
           textAlign: TextAlign.center,
         )
-            .animate(adapter: ValueNotifierAdapter(notifier))
+            .animate(adapter: ValueNotifierAdapter(notifier, duration: 0.ms))
             .blurXY(end: 16)
             .scaleXY(begin: 1, end: 2)
             .tint(color: const Color(0xFF80DDFF))
@@ -87,9 +87,7 @@ class AdapterView extends StatelessWidget {
                 colors: [Color(0x8080DDFF), Colors.transparent],
               ),
             ),
-          )
-              .animate(adapter: ScrollAdapter(scrollController, begin: -500))
-              .fadeOut(),
+          ).animate(adapter: ScrollAdapter(scrollController, begin: -500)).fadeOut(),
         ),
 
         // the list (with the scrollController assigned):

--- a/lib/adapters/value_notifier_adapter.dart
+++ b/lib/adapters/value_notifier_adapter.dart
@@ -6,17 +6,22 @@ import '../flutter_animate.dart';
 
 /// Drives an [Animate] animation from a [ValueNotifier]. The value from the
 /// notifier should be in the range `0-1`.
+/// The [Duration] parameter allows to enable or disable the animation, or update the Animation Duration:
+/// - set a `null` [Duration] (or leave it empty) to animate and preserve Animation parameters (default behavior) ;
+/// - set a zero [Duration] (short with `0.ms`) to disable the Animation ;
+/// - set a new [Duration] to update the Animation duration.
 @immutable
 class ValueNotifierAdapter extends Adapter {
-  ValueNotifierAdapter(this.notifier);
+  ValueNotifierAdapter(this.notifier, {this.duration});
 
   final ValueNotifier<double> notifier;
+  final Duration? duration;
 
   @override
   void init(AnimationController controller) {
     controller.value = notifier.value;
     notifier.addListener(() {
-      controller.value = notifier.value;
+      controller.animateTo(notifier.value, duration: duration);
     });
   }
 }


### PR DESCRIPTION
Before this update, the new value was directly set to the controller. The controller directly jumps to the new value, an no animation was computed.
Now, the controller will animate to the new value. Previously set animation parameters (Duration, Curve) will be preserved.

I've updated the adapter's example with this animation to provide an example of the adpater:

_Before_:
![Before](https://user-images.githubusercontent.com/7722167/188913762-9d8e734d-9237-4b8b-975c-14fd2c4f5be6.gif)


_After_:
![After](https://user-images.githubusercontent.com/7722167/188913727-054eb9cd-f275-4e7f-bffc-4267daacbdd6.gif)


Plus, I update the Slider's animation example, from a `ValueNotifierAdpater` to a `ValueAdapter`.
