### PR TITLE
Fix blur effect throw an error on web

### DIFF
--- a/lib/effects/blur_effect.dart
+++ b/lib/effects/blur_effect.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../flutter_animate.dart';
@@ -31,14 +32,16 @@ class BlurEffect extends Effect<double> {
     Animation<double> animation = buildAnimation(controller, entry);
     return getOptimizedBuilder<double>(
       animation: animation,
-      builder: (_, __) => ImageFiltered(
-        imageFilter: ImageFilter.blur(
-          sigmaX: animation.value,
-          sigmaY: animation.value,
-          tileMode: TileMode.decal,
-        ),
-        child: child,
-      ),
+      builder: (_, __) => (animation.value < 0.001)
+          ? child
+          : ImageFiltered(
+              imageFilter: ImageFilter.blur(
+                sigmaX: animation.value,
+                sigmaY: animation.value,
+                tileMode: TileMode.decal,
+              ),
+              child: child,
+            ),
     );
   }
 }


### PR DESCRIPTION
On Web, the blur effect throw an error when the Widget was fully unblur (so sigma values are close to 0.0). This happen on the begin of the `blur` animation, and on the end of the `unblur` one.

Here we disable the ImageFiltered Widget when we are close to zero value.
This error is still open on Flutter side: https://github.com/flutter/flutter/issues/89433

I'm not very convinced by my hack btw... 