### PR TITLE
Update pub.dev links

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_animate
 description: Add beautiful animated effects & builders in Flutter, via an easy, customizable, unified API.
 version: 1.0.0
 repository: https://github.com/gskinner/flutter_animate
-homepage: https://github.com/gskinner/flutter_animate
+issue_tracker: https://github.com/gskinner/flutter_animate/issues
 
 environment:
   sdk: ">=2.15.0 <3.0.0"


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).