### PR TITLE
improved NumDurationExtensions to make it more readable

### DIFF
--- a/lib/extensions/num_duration_extensions.dart
+++ b/lib/extensions/num_duration_extensions.dart
@@ -7,13 +7,10 @@
 /// ```
 extension NumDurationExtensions on num {
   Duration get microseconds => Duration(microseconds: round());
-  Duration get milliseconds => Duration(microseconds: (this * 1000).round());
-  Duration get seconds => Duration(microseconds: (this * 1000 * 1000).round());
-  Duration get minutes =>
-      Duration(microseconds: (this * 1000 * 1000 * 60).round());
-  Duration get hours =>
-      Duration(microseconds: (this * 1000 * 1000 * 60 * 60).round());
-  Duration get days =>
-      Duration(microseconds: (this * 1000 * 1000 * 60 * 60 * 24).round());
+  Duration get milliseconds => (this * 1000).microseconds;
+  Duration get seconds => (this * 1000).milliseconds;
+  Duration get minutes => (this * 60).seconds;
+  Duration get hours => (this * 60).minutes;
+  Duration get days => (this * 24).hours;
   Duration get ms => milliseconds;
 }

--- a/lib/extensions/num_duration_extensions.dart
+++ b/lib/extensions/num_duration_extensions.dart
@@ -8,9 +8,9 @@
 extension NumDurationExtensions on num {
   Duration get microseconds => Duration(microseconds: round());
   Duration get milliseconds => (this * 1000).microseconds;
-  Duration get seconds => (this * 1000).milliseconds;
-  Duration get minutes => (this * 60).seconds;
-  Duration get hours => (this * 60).minutes;
-  Duration get days => (this * 24).hours;
+  Duration get seconds => (this * 1000 * 1000).microseconds;
+  Duration get minutes => (this * 1000 * 1000 * 60).microseconds;
+  Duration get hours => (this * 1000 * 1000 * 60 * 60).microseconds;
+  Duration get days => (this * 1000 * 1000 * 60 * 60 * 24).microseconds;
   Duration get ms => milliseconds;
 }


### PR DESCRIPTION
When I was looking for the code of `NumDurationExtensions`, have to do a lot of computation and figuring out what 1000 or 60 is for what purpose

So, Tried to reduce it in more readable format.

For example:
1 day = 24 hours
`{someNum}.days` = someNum * 24 hours (this can be written as `({someNum} * 24).hours`) 

Similarly, for other extension also.

and `.microseconds` can take care of `.round()` at last.

Let me know what do you think? Or that microseconds is used deliberately?