### PR TITLE
Add the option to play the animation or just return the child in the `Animate` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1] - 2023-10-22
+### Added
+- A new property which is `isAnimationEnabled` to the `Animate` widget class
+
 ## [4.2.0] - 2023-06-19
 ### Added
 - `FollowPathEffect`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.2.1] - 2023-10-22
 ### Added
-- A new property which is `isAnimationEnabled` to the `Animate` widget class
+- A new property which is `enabled` to the `Animate` widget class
 
 ## [4.2.0] - 2023-06-19
 ### Added

--- a/lib/src/animate.dart
+++ b/lib/src/animate.dart
@@ -119,6 +119,7 @@ class Animate extends StatefulWidget with AnimateManager<Animate> {
     this.controller,
     this.adapter,
     this.target,
+    this.isAnimationEnabled = true,
   })  : autoPlay = autoPlay ?? true,
         delay = delay ?? Duration.zero,
         super(key: key) {
@@ -142,6 +143,13 @@ class Animate extends StatefulWidget with AnimateManager<Animate> {
 
   /// The widget to apply animated effects to.
   final Widget child;
+
+  /// If you don't want to play the animation and just return the child
+  /// for some reasons and you don't want to create helper widget or function
+  /// or builder that help to achieve that without too duplication
+  /// then please pass false to [isAnimationEnabled] as a value to return the
+  /// child directly
+  final bool isAnimationEnabled;
 
   /// Called immediately after the controller is fully initialized, before
   /// the [Animate.delay] or the animation starts playing (see: [onPlay]).
@@ -368,6 +376,10 @@ class _AnimateState extends State<Animate> with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     Widget child = widget.child, parent = child;
+
+    if (!widget.isAnimationEnabled) {
+      return child;
+    }
     ReparentChildBuilder? reparent = Animate.reparentTypes[child.runtimeType];
     if (reparent != null) child = (child as dynamic).child;
     for (EffectEntry entry in widget._entries) {

--- a/lib/src/animate.dart
+++ b/lib/src/animate.dart
@@ -108,7 +108,7 @@ class Animate extends StatefulWidget with AnimateManager<Animate> {
   /// Creates an Animate instance that will manage a list of effects and apply
   /// them to the specified child.
   Animate({
-    Key? key,
+    super.key,
     this.child = const SizedBox.shrink(),
     List<Effect>? effects,
     this.onInit,
@@ -119,10 +119,9 @@ class Animate extends StatefulWidget with AnimateManager<Animate> {
     this.controller,
     this.adapter,
     this.target,
-    this.isAnimationEnabled = true,
+    this.enabled = true,
   })  : autoPlay = autoPlay ?? true,
-        delay = delay ?? Duration.zero,
-        super(key: key) {
+        delay = delay ?? Duration.zero {
     warn(
       autoPlay != false || onPlay == null,
       'Animate.onPlay is not called when Animate.autoPlay=false',
@@ -147,9 +146,9 @@ class Animate extends StatefulWidget with AnimateManager<Animate> {
   /// If you don't want to play the animation and just return the child
   /// for some reasons and you don't want to create helper widget or function
   /// or builder that help to achieve that without too duplication
-  /// then please pass false to [isAnimationEnabled] as a value to return the
+  /// then please pass false to [enabled] as a value to return the
   /// child directly
-  final bool isAnimationEnabled;
+  final bool enabled;
 
   /// Called immediately after the controller is fully initialized, before
   /// the [Animate.delay] or the animation starts playing (see: [onPlay]).
@@ -377,7 +376,7 @@ class _AnimateState extends State<Animate> with SingleTickerProviderStateMixin {
   Widget build(BuildContext context) {
     Widget child = widget.child, parent = child;
 
-    if (!widget.isAnimationEnabled) {
+    if (!widget.enabled) {
       return child;
     }
     ReparentChildBuilder? reparent = Animate.reparentTypes[child.runtimeType];
@@ -403,6 +402,7 @@ extension AnimateWidgetExtensions on Widget {
     AnimationController? controller,
     Adapter? adapter,
     double? target,
+    bool enabled = true,
   }) =>
       Animate(
         key: key,
@@ -415,6 +415,7 @@ extension AnimateWidgetExtensions on Widget {
         controller: controller,
         adapter: adapter,
         target: target,
+        enabled: enabled,
         child: this,
       );
 }


### PR DESCRIPTION
Hi, not much changes, just a new property called `isAnimationEnabled`
tell me if I should rename it to fit your needs

sometimes when I don't want to play the animation for some reason or disable them all instead of using conditions or create helper class, function to do that I just add that built-in in the `Animate` class

Example

After:
```dart

Animate(
            effects: const [
              SlideEffect(),
            ],
            enabled: false,
            child: TextButton(
              onPressed: () async {
                print(jsonEncode(_controller.document.toDelta().toJson()));
              },
              child: const Icon(Icons.help_outline),
            ),
          ),

```

Before:

```dart

    Builder(
            builder: (context) {
              final child = TextButton(
                onPressed: () async {
                  print(jsonEncode(_controller.document.toDelta().toJson()));
                },
                child: const Icon(Icons.help_outline),
              );
              if (isAnimationEnabled) {
                return Animate(
                  effects: const [
                    SlideEffect(),
                  ],
                  child: child,
                );
              }
              return child;
            },
          )

```

That just an example 