### PR TITLE
Resolve ambiguous_extension_member_access error by refining extension constraints

### DIFF
--- a/lib/src/effects/align_effect.dart
+++ b/lib/src/effects/align_effect.dart
@@ -45,7 +45,7 @@ class AlignEffect extends Effect<Alignment> {
   }
 }
 
-extension AlignEffectExtensions<T> on AnimateManager<T> {
+extension AlignEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [align] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T align({
     Duration? delay,

--- a/lib/src/effects/blur_effect.dart
+++ b/lib/src/effects/blur_effect.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+
 import 'package:flutter/widgets.dart';
 
 import '../../flutter_animate.dart';
@@ -63,7 +64,7 @@ class BlurEffect extends Effect<Offset> {
   }
 }
 
-extension BlurEffectExtensions<T> on AnimateManager<T> {
+extension BlurEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [blur] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T blur({
     Duration? delay,

--- a/lib/src/effects/box_shadow_effect.dart
+++ b/lib/src/effects/box_shadow_effect.dart
@@ -55,7 +55,7 @@ class BoxShadowEffect extends Effect<BoxShadow> {
   }
 }
 
-extension BoxShadowEffectExtensions<T> on AnimateManager<T> {
+extension BoxShadowEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [boxShadow] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T boxShadow({
     Duration? delay,

--- a/lib/src/effects/callback_effect.dart
+++ b/lib/src/effects/callback_effect.dart
@@ -108,7 +108,7 @@ class CallbackEffect extends Effect<void> {
   }
 }
 
-extension CallbackEffectExtensions<T> on AnimateManager<T> {
+extension CallbackEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [callback] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T callback({
     Duration? delay,

--- a/lib/src/effects/color_effect.dart
+++ b/lib/src/effects/color_effect.dart
@@ -66,7 +66,7 @@ class ColorEffect extends Effect<Color?> {
   }
 }
 
-extension ColorEffectExtension<T> on AnimateManager<T> {
+extension ColorEffectExtension<T extends AnimateManager<T>> on T {
   /// Adds a [color] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T color({
     Duration? delay,

--- a/lib/src/effects/crossfade_effect.dart
+++ b/lib/src/effects/crossfade_effect.dart
@@ -48,7 +48,7 @@ class CrossfadeEffect extends Effect<double> {
   }
 }
 
-extension CrossfadeEffectExtensions<T> on AnimateManager<T> {
+extension CrossfadeEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [crossfade] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T crossfade({
     Duration? delay,

--- a/lib/src/effects/custom_effect.dart
+++ b/lib/src/effects/custom_effect.dart
@@ -54,7 +54,7 @@ class CustomEffect extends Effect<double> {
   }
 }
 
-extension CustomEffectExtensions<T> on AnimateManager<T> {
+extension CustomEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [custom] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T custom({
     required CustomEffectBuilder builder,

--- a/lib/src/effects/effect.dart
+++ b/lib/src/effects/effect.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+
 import '../../flutter_animate.dart';
 
 /// An empty effect that all other effects extend.
@@ -107,7 +108,7 @@ class Effect<T> {
   }
 }
 
-extension EffectExtensions<T> on AnimateManager<T> {
+extension EffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds an [effect] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T effect({
     Duration? delay,

--- a/lib/src/effects/elevation_effect.dart
+++ b/lib/src/effects/elevation_effect.dart
@@ -55,7 +55,7 @@ class ElevationEffect extends Effect<double> {
   }
 }
 
-extension ElevationEffectExtensions<T> on AnimateManager<T> {
+extension ElevationEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds an [elevation] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T elevation({
     Duration? delay,

--- a/lib/src/effects/fade_effect.dart
+++ b/lib/src/effects/fade_effect.dart
@@ -38,7 +38,7 @@ class FadeEffect extends Effect<double> {
   }
 }
 
-extension FadeEffectExtensions<T> on AnimateManager<T> {
+extension FadeEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [fade] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T fade({
     Duration? delay,

--- a/lib/src/effects/flip_effect.dart
+++ b/lib/src/effects/flip_effect.dart
@@ -94,7 +94,7 @@ class FlipEffect extends Effect<double> {
   }
 }
 
-extension FlipEffectExtensions<T> on AnimateManager<T> {
+extension FlipEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [flip] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T flip({
     Duration? delay,

--- a/lib/src/effects/follow_path_effect.dart
+++ b/lib/src/effects/follow_path_effect.dart
@@ -94,7 +94,7 @@ class FollowPathEffect extends Effect<double> {
   }
 }
 
-extension FollowPathEffectExtensions<T> on AnimateManager<T> {
+extension FollowPathEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [path] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T followPath({
     Duration? delay,

--- a/lib/src/effects/listen_effect.dart
+++ b/lib/src/effects/listen_effect.dart
@@ -75,7 +75,7 @@ class ListenEffect extends Effect<double> {
   }
 }
 
-extension ListenEffectExtensions<T> on AnimateManager<T> {
+extension ListenEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [listen] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T listen({
     Duration? delay,

--- a/lib/src/effects/move_effect.dart
+++ b/lib/src/effects/move_effect.dart
@@ -56,7 +56,7 @@ class MoveEffect extends Effect<Offset> {
   }
 }
 
-extension MoveEffectExtensions<T> on AnimateManager<T> {
+extension MoveEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [move] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T move({
     Duration? delay,

--- a/lib/src/effects/rotate_effect.dart
+++ b/lib/src/effects/rotate_effect.dart
@@ -48,7 +48,7 @@ class RotateEffect extends Effect<double> {
   }
 }
 
-extension RotateEffectExtensions<T> on AnimateManager<T> {
+extension RotateEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [rotate] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T rotate({
     Duration? delay,

--- a/lib/src/effects/saturate_effect.dart
+++ b/lib/src/effects/saturate_effect.dart
@@ -63,7 +63,7 @@ class SaturateEffect extends Effect<double> {
   }
 }
 
-extension SaturateEffectExtensions<T> on AnimateManager<T> {
+extension SaturateEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [saturate] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T saturate({
     Duration? delay,

--- a/lib/src/effects/scale_effect.dart
+++ b/lib/src/effects/scale_effect.dart
@@ -52,7 +52,7 @@ class ScaleEffect extends Effect<Offset> {
   }
 }
 
-extension ScaleEffectExtensions<T> on AnimateManager<T> {
+extension ScaleEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [scale] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T scale({
     Duration? delay,

--- a/lib/src/effects/shader_effect.dart
+++ b/lib/src/effects/shader_effect.dart
@@ -1,7 +1,6 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/rendering.dart';
-
 import 'package:flutter/widgets.dart';
 
 import '../../flutter_animate.dart';
@@ -123,7 +122,7 @@ class ShaderEffect extends Effect<double> {
   }
 }
 
-extension ShaderEffectExtensions<T> on AnimateManager<T> {
+extension ShaderEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [shader] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T shader({
     Duration? delay,

--- a/lib/src/effects/shake_effect.dart
+++ b/lib/src/effects/shake_effect.dart
@@ -80,7 +80,7 @@ class ShakeEffect extends Effect<double> {
   }
 }
 
-extension ShakeEffectExtensions<T> on AnimateManager<T> {
+extension ShakeEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [shake] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T shake({
     Duration? delay,

--- a/lib/src/effects/shimmer_effect.dart
+++ b/lib/src/effects/shimmer_effect.dart
@@ -10,7 +10,7 @@ import '../../flutter_animate.dart';
 /// **IMPORTANT:** Due to current limitations in Flutter, this effect may cause
 /// issues on mobile web when using the HTML renderer. More info can be found
 /// [here](https://github.com/gskinner/flutter_animate/issues/78).
-/// 
+///
 /// **NOTE:*** By default, this effect adds 0.5px of [padding] to its target to
 /// prevent visual issues, which could effect layout.
 ///
@@ -113,7 +113,7 @@ class ShimmerEffect extends Effect<double> {
   }
 }
 
-extension ShimmerEffectExtensions<T> on AnimateManager<T> {
+extension ShimmerEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [shimmer] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T shimmer({
     Duration? delay,

--- a/lib/src/effects/slide_effect.dart
+++ b/lib/src/effects/slide_effect.dart
@@ -44,7 +44,7 @@ class SlideEffect extends Effect<Offset> {
   }
 }
 
-extension SlideEffectExtensions<T> on AnimateManager<T> {
+extension SlideEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [slide] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T slide({
     Duration? delay,

--- a/lib/src/effects/swap_effect.dart
+++ b/lib/src/effects/swap_effect.dart
@@ -67,7 +67,7 @@ class SwapEffect extends Effect<void> {
   }
 }
 
-extension SwapEffectExtensions<T> on AnimateManager<T> {
+extension SwapEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [swap] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T swap({
     Duration? delay,

--- a/lib/src/effects/then_effect.dart
+++ b/lib/src/effects/then_effect.dart
@@ -36,7 +36,7 @@ class ThenEffect extends Effect<double> {
       child;
 }
 
-extension ThenEffectExtensions<T> on AnimateManager<T> {
+extension ThenEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [then] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T then({Duration? delay, Duration? duration, Curve? curve}) =>
       addEffect(ThenEffect(delay: delay, duration: duration, curve: curve));

--- a/lib/src/effects/tint_effect.dart
+++ b/lib/src/effects/tint_effect.dart
@@ -72,7 +72,7 @@ class TintEffect extends Effect<double> {
   }
 }
 
-extension TintEffectExtensions<T> on AnimateManager<T> {
+extension TintEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [tint] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T tint({
     Duration? delay,

--- a/lib/src/effects/toggle_effect.dart
+++ b/lib/src/effects/toggle_effect.dart
@@ -49,7 +49,7 @@ class ToggleEffect extends Effect<void> {
   }
 }
 
-extension ToggleEffectExtensions<T> on AnimateManager<T> {
+extension ToggleEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [toggle] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T toggle({
     Duration? delay,

--- a/lib/src/effects/visibility_effect.dart
+++ b/lib/src/effects/visibility_effect.dart
@@ -50,7 +50,7 @@ class VisibilityEffect extends Effect<bool> {
   }
 }
 
-extension VisibilityEffectExtensions<T> on AnimateManager<T> {
+extension VisibilityEffectExtensions<T extends AnimateManager<T>> on T {
   /// Adds a [visibility] extension to [AnimateManager] ([Animate] and [AnimateList]).
   T visibility({
     Duration? delay,


### PR DESCRIPTION
### Description

#### Summary:

This PR refines the type constraint for all `ExtensionEffect` extension to prevent the `ambiguous_extension_member_access` error when two extension methods conflict by name.

#### Issue:

Currently, when multiple extensions define a method with the same name, Dart throws an `ambiguous_extension_member_access` error. This becomes problematic for users who want to apply their own extensions alongside this package. 

#### Reproduction:

```dart
extension ExtensionA<T> on AnimateManager<T> {
  String letter() => 'A'; // conflicts with B
}
extension ExtensionB on Widget {
  String letter() => 'B'; // conflicts with A
}

widget.animate().letter() // ERROR: `ambiguous_extension_member_access`
```

#### Solution:

The PR changes the extension definition from:

```dart
extension ExtensionEffect<T> on AnimateManager<T> {...}
```

to:

```dart
extension ExtensionEffect<T extends AnimateManager<T>> on T {...}
```

With this change, invoking `animate().letter()` correctly resolves to 'A' or 'B' correctly, eliminating the ambiguity.

This is also type safer as indicates that `Type extends Subtype<Type>` instead of `Any extends Subtype<Type>`, which follows better `Animate extends AnimateManager<Animate>` constraints, where you always want to return the same instance.

#### Tests:

I ran `flutter test` and the package worked as usual. For the conflict behaviour, you can check this on DartPad to verify the behaviour:

```dart
class Animate extends StatefulWidget with AnimateManager<Animate> {
  @override
  State<StatefulWidget> createState() => throw UnimplementedError();
}

mixin AnimateManager<T> {}

// Conflicts with B
extension ExtensionA<T> on AnimateManager<T> {
  String letter() => 'A';
}

// Another extension
extension ExtensionB on Widget {
  String letter() => 'B';
}

// Does not conflict with B
extension ExtensionNewA<T extends AnimateManager<T>> on T {
  String letter() => 'A';
}

void main() async {
 
  Animate animate() => Animate();
  
  final letter = animate().letter();

  print(letter); // 'A'
}
```

#### Impact:

This change makes the package more flexible and compatible with other packages and user-defined extensions. 

For example, with these changes, both can coexist:

```dart
Text('hi')
   .scale(2) // user or package extension
   .animate()
   .scale(end: 1.5) // flutter_animate extension
```

### Conclusion

By refining the type constraints on our extension, we can prevent method conflicts and make this package more flexible and interoperable.

---

I'm open to discuss about this. I love this package, great work!